### PR TITLE
#0: Get rid of default for CHECKOUT_TOKEN secret as it's invalid syntax + use JS && to checkout a repo

### DIFF
--- a/.github/workflows/release-verify-or-create-tag.yaml
+++ b/.github/workflows/release-verify-or-create-tag.yaml
@@ -17,8 +17,8 @@ on:
         type: boolean
     secrets:
       CHECKOUT_TOKEN:
-        required: true
-        default: ${{ github.token }}
+        description: "Optional token to checkout target repo to tag/release"
+        required: false
     outputs:
       version:
         description: "New version"
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.CHECKOUT_TOKEN }}
+          token: ${{ secrets.CHECKOUT_TOKEN && github.token }}
           fetch-depth: ${{ inputs.fetch_depth }}
       - uses: paulhatch/semantic-version@v5.0.2
         id: get-next-semantic-base-version


### PR DESCRIPTION
…